### PR TITLE
Move Swankdown to next-to-last in side projects

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,14 +43,6 @@ const experience = [
 
 const sideProjects = [
   {
-    name: "Swankdown",
-    url: "https://swankdown.gustavosaiani.com",
-    domain: "swankdown.gustavosaiani.com",
-    description:
-      "Transforms Markdown into beautifully typeset reading pages with refined typography.",
-    image: "/images/swankdown.png",
-  },
-  {
     name: "Poema Investimentos",
     url: "https://poe.ma",
     domain: "poe.ma",
@@ -72,6 +64,14 @@ const sideProjects = [
     description:
       "Financial indicators for Brazilian public companies, built for value investors.",
     image: "/images/sponda.png",
+  },
+  {
+    name: "Swankdown",
+    url: "https://swankdown.gustavosaiani.com",
+    domain: "swankdown.gustavosaiani.com",
+    description:
+      "Transforms Markdown into beautifully typeset reading pages with refined typography.",
+    image: "/images/swankdown.png",
   },
   {
     name: "Art Portfolio",


### PR DESCRIPTION
## Summary
- Reorders Swankdown from first to next-to-last position (before Art Portfolio) in the side projects list

## Test plan
- [ ] Verify side projects order: Poema, Doing It, Sponda, Swankdown, Art Portfolio