### PR TITLE
Update Poema returns to Mar 2026 figures

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,7 +47,7 @@ const sideProjects = [
     url: "https://poe.ma",
     domain: "poe.ma",
     description:
-      "Value investment partnership. 356% cumulative returns from Jan 2017 to Dec 2025, outperforming the Brazilian stock index by 2.1x.",
+      "Value investment partnership. 395% cumulative returns from Jan 2017 to Mar 2026, outperforming the Brazilian stock index by 1.9x.",
     image: "/images/poema.png",
   },
   {


### PR DESCRIPTION
## Summary
- Update Poema cumulative returns from 356% (Dec 2025) to 395% (Mar 2026)
- Update outperformance ratio from 2.1x to 1.9x

## Test plan
- [ ] Verify the updated text renders correctly on the homepage