### PR TITLE
Unify experience and projects into two-column card layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -249,33 +249,60 @@ img {
   margin: 0;
 }
 
-/* ── EXPERIENCE CARDS ── */
+/* ── TWO-COLUMN LAYOUT ── */
 
-.experience-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4rem;
-}
-
-.exp-card {
+.two-col-layout {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 3rem;
-  align-items: center;
+  align-items: start;
 }
 
-.exp-card:nth-child(even) {
-  direction: rtl;
+.col .section-header {
+  margin-bottom: 1.5rem;
 }
 
-.exp-card:nth-child(even) > * {
-  direction: ltr;
-}
-
-.exp-info {
+.card-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition: border-color 0.3s, transform 0.3s, box-shadow 0.3s;
+  display: block;
+}
+
+.card:hover {
+  border-color: var(--border-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.06);
+}
+
+.card-thumb {
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+}
+
+.card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top;
+  transition: transform 0.4s ease;
+}
+
+.card:hover .card-thumb img {
+  transform: scale(1.02);
+}
+
+.card-body {
+  padding: 1.25rem 1.5rem 1.5rem;
 }
 
 .exp-period {
@@ -284,43 +311,46 @@ img {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--text-muted);
-}
-
-.exp-company {
-  font-size: 1.75rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--text-primary);
-}
-
-.exp-company a {
-  transition: color 0.2s;
-}
-
-.exp-company a:hover {
-  color: var(--accent);
+  display: block;
+  margin-bottom: 0.5rem;
 }
 
 .exp-role {
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   color: var(--accent);
   font-weight: 500;
+  display: block;
+  margin-bottom: 0.75rem;
 }
 
-.exp-desc {
-  font-size: 0.9375rem;
+.card-name {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  color: var(--text-primary);
+}
+
+.card-url {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: ui-monospace, "SF Mono", "Cascadia Code", "Segoe UI Mono", Menlo, monospace;
+  margin-bottom: 0.75rem;
+}
+
+.card-description {
+  font-size: 0.875rem;
   color: var(--text-secondary);
-  line-height: 1.7;
+  line-height: 1.6;
 }
 
-.exp-tech {
+.card-tech {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-top: 0.5rem;
+  margin-top: 0.75rem;
 }
 
-.exp-tech span {
+.card-tech span {
   font-size: 0.6875rem;
   font-weight: 500;
   letter-spacing: 0.05em;
@@ -330,133 +360,6 @@ img {
   border-radius: 4px;
 }
 
-/* ── BROWSER MOCKUP ── */
-
-.browser-frame {
-  background: var(--bg-card);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  overflow: hidden;
-  transition: border-color 0.3s, box-shadow 0.3s;
-}
-
-.browser-frame:hover {
-  border-color: var(--border-hover);
-  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.08);
-}
-
-.browser-chrome {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: var(--bg-elevated);
-  border-bottom: 1px solid var(--border);
-}
-
-.browser-dots {
-  display: flex;
-  gap: 6px;
-}
-
-.browser-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--border-hover);
-}
-
-.browser-url {
-  flex: 1;
-  font-size: 0.6875rem;
-  color: var(--text-muted);
-  background: var(--bg);
-  padding: 0.25rem 0.75rem;
-  border-radius: 4px;
-  margin-left: 0.5rem;
-  font-family: ui-monospace, "SF Mono", "Cascadia Code", "Segoe UI Mono", Menlo, monospace;
-}
-
-.browser-viewport {
-  position: relative;
-  overflow: hidden;
-  aspect-ratio: 16 / 9;
-}
-
-.browser-viewport img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: top;
-}
-
-/* ── SIDE PROJECTS ── */
-
-.projects-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-}
-
-.project-card {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  overflow: hidden;
-  transition: border-color 0.3s, transform 0.3s, box-shadow 0.3s;
-}
-
-.project-card:hover {
-  border-color: var(--border-hover);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.06);
-}
-
-.project-thumb {
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-  border-bottom: 1px solid var(--border);
-}
-
-.project-thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: top;
-  transition: transform 0.4s ease;
-}
-
-.project-card:hover .project-thumb img {
-  transform: scale(1.02);
-}
-
-.project-body {
-  padding: 1.25rem 1.5rem 1.5rem;
-}
-
-.project-name {
-  font-size: 1.125rem;
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-  color: var(--text-primary);
-}
-
-.project-name a:hover {
-  color: var(--accent);
-}
-
-.project-url {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  font-family: ui-monospace, "SF Mono", "Cascadia Code", "Segoe UI Mono", Menlo, monospace;
-  margin-bottom: 0.75rem;
-}
-
-.project-description {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
 
 /* ── SKILLS ── */
 
@@ -560,16 +463,7 @@ img {
 /* ── RESPONSIVE ── */
 
 @media (max-width: 900px) {
-  .exp-card {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
-  }
-
-  .exp-card:nth-child(even) {
-    direction: ltr;
-  }
-
-  .projects-grid {
+  .two-col-layout {
     grid-template-columns: 1fr;
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,7 +41,7 @@ const experience = [
   },
 ];
 
-const sideProjects = [
+const projects = [
   {
     name: "Poema Investimentos",
     url: "https://poe.ma",
@@ -49,6 +49,7 @@ const sideProjects = [
     description:
       "Value investment partnership. 395% cumulative returns from Jan 2017 to Mar 2026, outperforming the Brazilian stock index by 1.9x.",
     image: "/images/poema.png",
+    tech: ["HTML", "CSS", "JavaScript", "Python"],
   },
   {
     name: "Doing It",
@@ -56,6 +57,7 @@ const sideProjects = [
     domain: "doingit.online",
     description: "Minimalist task and time tracker. Type a task name and start the clock.",
     image: "/images/doingit.png",
+    tech: ["Python", "FastAPI", "PostgreSQL", "Playwright", "Stripe", "Docker"],
   },
   {
     name: "Sponda",
@@ -64,6 +66,7 @@ const sideProjects = [
     description:
       "Financial indicators for Brazilian public companies, built for value investors.",
     image: "/images/sponda.png",
+    tech: ["Next.js", "React", "TypeScript", "Django", "PostgreSQL", "Tailwind CSS", "Docker"],
   },
   {
     name: "Swankdown",
@@ -72,6 +75,7 @@ const sideProjects = [
     description:
       "Transforms Markdown into beautifully typeset reading pages with refined typography.",
     image: "/images/swankdown.png",
+    tech: ["Node.js", "JavaScript"],
   },
   {
     name: "Art Portfolio",
@@ -79,6 +83,7 @@ const sideProjects = [
     domain: "gustavosaiani.art.br",
     description: "Paintings portfolio.",
     image: "/images/artbr.png",
+    tech: ["React", "React Router"],
   },
   {
     name: "AI Engineering",
@@ -87,6 +92,7 @@ const sideProjects = [
     description:
       "Project-based AI engineering curriculum. 13 modules from LLM API basics to multi-agent systems, built for portfolio over credentials.",
     image: "/images/ai-engineering.png",
+    tech: ["Python", "Anthropic SDK", "OpenAI SDK"],
   },
 ];
 
@@ -97,32 +103,6 @@ const skills = {
   "Tools & Infra": ["Claude Code", "Gemini", "AWS", "Docker", "Django", "PostgreSQL", "GraphQL", "ESLint", "Prettier", "GitHub"],
 };
 
-function BrowserFrame({
-  url,
-  image,
-  alt,
-}: {
-  url: string;
-  image: string;
-  alt: string;
-}) {
-  const displayUrl = url.replace("https://", "");
-  return (
-    <a href={url} target="_blank" rel="noopener noreferrer" className="browser-frame">
-      <div className="browser-chrome">
-        <div className="browser-dots">
-          <span className="browser-dot" />
-          <span className="browser-dot" />
-          <span className="browser-dot" />
-        </div>
-        <span className="browser-url">{displayUrl}</span>
-      </div>
-      <div className="browser-viewport">
-        <img src={image} alt={alt} loading="lazy" />
-      </div>
-    </a>
-  );
-}
 
 export default function Home() {
   return (
@@ -181,66 +161,77 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Experience */}
+      {/* Experience & Projects */}
       <hr className="section-divider" />
       <section id="experience" className="section">
         <div className="section-inner">
-          <div className="section-header">
-            <p className="section-label">Experience</p>
-            <h2 id="where-ive-worked" className="section-title">Where I&apos;ve worked</h2>
-          </div>
-          <div className="experience-list">
-            {experience.map((exp) => (
-              <div key={exp.company} className="exp-card">
-                <div className="exp-info">
-                  <span className="exp-period">{exp.period}</span>
-                  <h3 id={exp.company.toLowerCase().replace(/\s+/g, "-")} className="exp-company">
-                    <a href={exp.url} target="_blank" rel="noopener noreferrer">
-                      {exp.company}
-                    </a>
-                  </h3>
-                  <span className="exp-role">{exp.role}</span>
-                  <p className="exp-desc">{exp.description}</p>
-                  <div className="exp-tech">
-                    {exp.tech.map((t) => (
-                      <span key={t}>{t}</span>
-                    ))}
-                  </div>
-                </div>
-                <BrowserFrame url={exp.url} image={exp.image} alt={`${exp.company} screenshot`} />
+          <div className="two-col-layout">
+            {/* Left column: Where I worked */}
+            <div className="col">
+              <div className="section-header">
+                <p className="section-label">Experience</p>
+                <h2 id="where-ive-worked" className="section-title">Where I worked</h2>
               </div>
-            ))}
-          </div>
-        </div>
-      </section>
+              <div className="card-list">
+                {experience.map((exp) => (
+                  <a
+                    key={exp.company}
+                    href={exp.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="card"
+                  >
+                    <div className="card-thumb">
+                      <img src={exp.image} alt={`${exp.company} screenshot`} loading="lazy" />
+                    </div>
+                    <div className="card-body">
+                      <span className="exp-period">{exp.period}</span>
+                      <h3 id={exp.company.toLowerCase().replace(/\s+/g, "-")} className="card-name">{exp.company}</h3>
+                      <span className="exp-role">{exp.role}</span>
+                      <p className="card-description">{exp.description}</p>
+                      <div className="card-tech">
+                        {exp.tech.map((t) => (
+                          <span key={t}>{t}</span>
+                        ))}
+                      </div>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </div>
 
-      {/* Side Projects */}
-      <hr className="section-divider" />
-      <section id="projects" className="section">
-        <div className="section-inner">
-          <div className="section-header">
-            <p className="section-label">Side Projects</p>
-            <h2 id="things-im-building" className="section-title">Things I&apos;m building</h2>
-          </div>
-          <div className="projects-grid">
-            {sideProjects.map((proj) => (
-              <a
-                key={proj.name}
-                href={proj.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="project-card"
-              >
-                <div className="project-thumb">
-                  <img src={proj.image} alt={`${proj.name} screenshot`} loading="lazy" />
-                </div>
-                <div className="project-body">
-                  <h3 id={proj.name.toLowerCase().replace(/\s+/g, "-")} className="project-name">{proj.name}</h3>
-                  <p className="project-url">{proj.domain}</p>
-                  <p className="project-description">{proj.description}</p>
-                </div>
-              </a>
-            ))}
+            {/* Right column: Projects */}
+            <div className="col" id="projects">
+              <div className="section-header">
+                <p className="section-label">Projects</p>
+                <h2 id="things-im-building" className="section-title">Things I&apos;m building</h2>
+              </div>
+              <div className="card-list">
+                {projects.map((proj) => (
+                  <a
+                    key={proj.name}
+                    href={proj.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="card"
+                  >
+                    <div className="card-thumb">
+                      <img src={proj.image} alt={`${proj.name} screenshot`} loading="lazy" />
+                    </div>
+                    <div className="card-body">
+                      <h3 id={proj.name.toLowerCase().replace(/\s+/g, "-")} className="card-name">{proj.name}</h3>
+                      <p className="card-url">{proj.domain}</p>
+                      <p className="card-description">{proj.description}</p>
+                      <div className="card-tech">
+                        {proj.tech.map((t) => (
+                          <span key={t}>{t}</span>
+                        ))}
+                      </div>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Merges Experience and Side Projects into a single two-column section: "Where I worked" (left) and "Projects" (right)
- Both columns use the same card component: image on top, text below
- Adds technology tags to all projects (Poema, Doing It, Sponda, Swankdown, Art Portfolio, AI Engineering)
- Removes the alternating browser-mockup layout and unused BrowserFrame component
- Renames "Side Projects" to "Projects"

## Test plan
- [ ] Desktop: two columns render side by side with cards stacking vertically within each column
- [ ] Mobile (≤900px): columns collapse to single column
- [ ] All experience cards show screenshot, period, company, role, description, and tech tags
- [ ] All project cards show screenshot, name, URL, description, and tech tags
- [ ] Card hover effects work (border, translate, shadow, image scale)
- [ ] Nav links to #experience and #projects still scroll correctly