### PR TITLE
Add full tech stacks to projects with expandable tags

### DIFF
--- a/app/expandable-tech.tsx
+++ b/app/expandable-tech.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ExpandableTech({
+  tech,
+  limit = 15,
+}: {
+  tech: string[];
+  limit?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? tech : tech.slice(0, limit);
+  const hasMore = tech.length > limit;
+
+  return (
+    <div className="card-tech">
+      {visible.map((t) => (
+        <span key={t}>{t}</span>
+      ))}
+      {hasMore && !expanded && (
+        <button
+          className="tech-more"
+          onClick={(e) => {
+            e.preventDefault();
+            setExpanded(true);
+          }}
+        >
+          More&hellip;
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -360,6 +360,24 @@ img {
   border-radius: 4px;
 }
 
+.tech-more {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  padding: 0.3rem 0.625rem;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.tech-more:hover {
+  border-color: var(--border-hover);
+  color: var(--text-primary);
+}
+
 
 /* ── SKILLS ── */
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import ExpandableTech from "./expandable-tech";
+
 const experience = [
   {
     company: "Metabase",
@@ -43,13 +45,19 @@ const experience = [
 
 const projects = [
   {
-    name: "Poema Investimentos",
-    url: "https://poe.ma",
-    domain: "poe.ma",
+    name: "Sponda",
+    url: "https://sponda.capital",
+    domain: "sponda.capital",
     description:
-      "Value investment partnership. 395% cumulative returns from Jan 2017 to Mar 2026, outperforming the Brazilian stock index by 1.9x.",
-    image: "/images/poema.png",
-    tech: ["HTML", "CSS", "JavaScript", "Python"],
+      "Financial indicators for Brazilian public companies, built for value investors.",
+    image: "/images/sponda.png",
+    tech: [
+      "Claude Code", "Codex",
+      "TypeScript", "React", "Next.js", "Tailwind CSS", "TanStack React Query", "Recharts", "Vite", "PostCSS",
+      "Python", "Django", "Django REST Framework", "PostgreSQL", "Redis", "Gunicorn", "Google OAuth", "BRAPI", "Financial Modeling Prep", "Resend",
+      "Vitest", "Testing Library", "Playwright", "pytest", "Factory Boy",
+      "Docker", "Docker Compose", "Nginx", "Let's Encrypt", "DigitalOcean", "systemd", "SSH", "GitHub", "GitHub Actions", "Node.js", "npm", "uv",
+    ],
   },
   {
     name: "Doing It",
@@ -57,16 +65,40 @@ const projects = [
     domain: "doingit.online",
     description: "Minimalist task and time tracker. Type a task name and start the clock.",
     image: "/images/doingit.png",
-    tech: ["Python", "FastAPI", "PostgreSQL", "Playwright", "Stripe", "Docker"],
+    tech: [
+      "Python", "FastAPI", "Uvicorn", "Pydantic",
+      "JavaScript", "HTML", "CSS",
+      "PostgreSQL", "psycopg2",
+      "Stripe", "Resend", "Google OAuth", "JWT", "Bcrypt",
+      "pytest", "Playwright",
+      "PostHog", "Google Analytics",
+      "Docker", "Fly.io", "GitHub Actions", "Makefile",
+    ],
   },
   {
-    name: "Sponda",
-    url: "https://sponda.capital",
-    domain: "sponda.capital",
+    name: "AI Engineering",
+    url: "https://github.com/gusaiani/ai-engineering",
+    domain: "github.com/gusaiani/ai-engineering",
     description:
-      "Financial indicators for Brazilian public companies, built for value investors.",
-    image: "/images/sponda.png",
-    tech: ["Next.js", "React", "TypeScript", "Django", "PostgreSQL", "Tailwind CSS", "Docker"],
+      "Project-based AI engineering curriculum. 13 modules from LLM API basics to multi-agent systems, built for portfolio over credentials.",
+    image: "/images/ai-engineering.png",
+    tech: [
+      "Python", "Anthropic SDK", "OpenAI SDK",
+      "Prompt Engineering", "RAG", "Embeddings", "Semantic Search", "pgvector",
+      "AI Agents", "Tool Use", "Multi-agent Systems", "LangChain", "LangGraph",
+      "Evals", "Observability", "LLMOps",
+      "Streaming", "Fine-tuning", "Multimodal",
+      "FastAPI",
+    ],
+  },
+  {
+    name: "Poema Investimentos",
+    url: "https://poe.ma",
+    domain: "poe.ma",
+    description:
+      "Value investment partnership. 395% cumulative returns from Jan 2017 to Mar 2026, outperforming the Brazilian stock index by 1.9x.",
+    image: "/images/poema.png",
+    tech: ["HTML", "CSS", "JavaScript", "Python"],
   },
   {
     name: "Swankdown",
@@ -84,15 +116,6 @@ const projects = [
     description: "Paintings portfolio.",
     image: "/images/artbr.png",
     tech: ["React", "React Router"],
-  },
-  {
-    name: "AI Engineering",
-    url: "https://github.com/gusaiani/ai-engineering",
-    domain: "github.com/gusaiani/ai-engineering",
-    description:
-      "Project-based AI engineering curriculum. 13 modules from LLM API basics to multi-agent systems, built for portfolio over credentials.",
-    image: "/images/ai-engineering.png",
-    tech: ["Python", "Anthropic SDK", "OpenAI SDK"],
   },
 ];
 
@@ -189,11 +212,7 @@ export default function Home() {
                       <h3 id={exp.company.toLowerCase().replace(/\s+/g, "-")} className="card-name">{exp.company}</h3>
                       <span className="exp-role">{exp.role}</span>
                       <p className="card-description">{exp.description}</p>
-                      <div className="card-tech">
-                        {exp.tech.map((t) => (
-                          <span key={t}>{t}</span>
-                        ))}
-                      </div>
+                      <ExpandableTech tech={exp.tech} />
                     </div>
                   </a>
                 ))}
@@ -222,11 +241,7 @@ export default function Home() {
                       <h3 id={proj.name.toLowerCase().replace(/\s+/g, "-")} className="card-name">{proj.name}</h3>
                       <p className="card-url">{proj.domain}</p>
                       <p className="card-description">{proj.description}</p>
-                      <div className="card-tech">
-                        {proj.tech.map((t) => (
-                          <span key={t}>{t}</span>
-                        ))}
-                      </div>
+                      <ExpandableTech tech={proj.tech} />
                     </div>
                   </a>
                 ))}


### PR DESCRIPTION
## Summary
- Moves Sponda to first project with complete tech stack (35 tags), ordered: AI → frontend → backend → testing → devops
- Doing It gets full stack from codebase scan: FastAPI, Stripe, Fly.io, PostHog, etc.
- AI Engineering gets curriculum topics from README: RAG, Embeddings, Evals, Multi-agent Systems, etc.
- Tags beyond 15 collapse behind a "More…" button (ExpandableTech client component)

## Test plan
- [ ] Sponda appears first in Projects column
- [ ] "More…" button appears on Sponda, Doing It, AI Engineering cards
- [ ] Clicking "More…" expands to show all tags, button disappears
- [ ] Clicking "More…" does not navigate away (preventDefault on anchor)
- [ ] Cards with ≤15 tags (Poema, Swankdown, Art Portfolio) show all tags without button
- [ ] Mobile layout still stacks correctly