### PR TITLE
Expand skills section with all tech from experience and projects

### DIFF
--- a/app/expandable-tech.tsx
+++ b/app/expandable-tech.tsx
@@ -5,18 +5,22 @@ import { useState } from "react";
 export default function ExpandableTech({
   tech,
   limit = 15,
+  listClassName = "card-tech",
+  tagClassName,
 }: {
   tech: string[];
   limit?: number;
+  listClassName?: string;
+  tagClassName?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
   const visible = expanded ? tech : tech.slice(0, limit);
   const hasMore = tech.length > limit;
 
   return (
-    <div className="card-tech">
+    <div className={listClassName}>
       {visible.map((t) => (
-        <span key={t}>{t}</span>
+        <span key={t} className={tagClassName}>{t}</span>
       ))}
       {hasMore && !expanded && (
         <button

--- a/app/globals.css
+++ b/app/globals.css
@@ -383,7 +383,7 @@ img {
 
 .skills-section {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 2rem;
 }
 
@@ -486,7 +486,7 @@ img {
   }
 
   .skills-section {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
   }
 
   .footer-inner {
@@ -512,6 +512,10 @@ img {
 }
 
 @media (max-width: 600px) {
+  .skills-section {
+    grid-template-columns: 1fr;
+  }
+
   .nav-links {
     display: none;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -133,12 +133,16 @@ const projects = [
   },
 ];
 
-const skills = {
-  Languages: ["JavaScript", "TypeScript", "Node.js", "HTML5", "CSS3", "Python", "Elixir", "Ruby"],
-  Libraries: ["React 19", "Next.js", "TanStack (Router, Query)", "Redux", "Tailwind CSS", "Styled Components", "Vite", "Webpack", "Storybook"],
-  Testing: ["Playwright", "Jest", "Vitest", "Cypress"],
-  "Tools & Infra": ["Claude Code", "Gemini", "AWS", "Docker", "Django", "PostgreSQL", "GraphQL", "ESLint", "Prettier", "GitHub"],
-};
+const skills: [string, string[]][] = [
+  ["Languages", ["JavaScript", "TypeScript", "Node.js", "HTML5", "CSS3", "Python", "Elixir", "Ruby", "Clojure", "SQL", "Shell"]],
+  ["AI", ["Claude Code", "Codex", "Anthropic SDK", "OpenAI SDK", "Prompt Engineering", "RAG", "Embeddings", "Semantic Search", "AI Agents", "Tool Use", "Multi-agent Systems", "LangChain", "LangGraph", "Evals", "Observability", "LLMOps", "Streaming", "Fine-tuning", "Multimodal", "pgvector"]],
+  ["Libraries", ["React 19", "Next.js", "TanStack (Router, Query)", "Redux", "Apollo", "GraphQL", "Tailwind CSS", "Styled Components", "Mantine", "Recharts", "PostCSS", "Vite", "Rspack", "Babel", "Bun", "Webpack", "Storybook", "Pydantic", "Resend"]],
+  ["Backend", ["Django", "Django REST Framework", "FastAPI", "Ruby on Rails", "ActiveRecord", "Gunicorn", "Uvicorn", "Elasticsearch", "Redis", "Shadow-cljs"]],
+  ["Databases", ["PostgreSQL", "pgvector", "Redis"]],
+  ["Testing", ["Playwright", "Jest", "Vitest", "Cypress", "pytest", "Factory Boy", "Testing Library", "Codecov"]],
+  ["DevOps & Infra", ["Docker", "Docker Compose", "Nginx", "GitHub", "GitHub Actions", "AWS", "DigitalOcean", "Fly.io", "systemd", "SSH", "Let's Encrypt", "Google Cloud Functions", "Husky"]],
+  ["Tools", ["ESLint", "Prettier", "Stylelint", "EditorConfig", "Makefile", "npm", "uv", "PostHog", "Google Analytics", "Google OAuth", "Stripe", "JWT", "Bcrypt", "BRAPI", "Financial Modeling Prep"]],
+];
 
 
 export default function Home() {
@@ -274,14 +278,10 @@ export default function Home() {
             <h2 id="technical-toolkit" className="section-title">Technical toolkit</h2>
           </div>
           <div className="skills-section">
-            {Object.entries(skills).map(([group, items]) => (
+            {skills.map(([group, items]) => (
               <div key={group}>
                 <h3 id={group.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")} className="skill-group-title">{group}</h3>
-                <div className="skill-list">
-                  {items.map((skill) => (
-                    <span key={skill} className="skill-tag">{skill}</span>
-                  ))}
-                </div>
+                <ExpandableTech tech={items} limit={10} listClassName="skill-list" tagClassName="skill-tag" />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Grows skills from 4 groups (31 tags) to 8 groups (80+ tags), sourced from every experience and project card
- New groups: AI (20 tags), Backend (10), Databases (3), DevOps & Infra (13), Tools (15) — plus expanded Languages, Libraries, Testing
- AI block placed right after Languages
- Each group shows 10 tags with "More…" to expand
- Grid: 4 columns desktop, 2 tablet, 1 mobile

## Test plan
- [ ] 8 skill groups render in a 4-column grid on desktop
- [ ] AI group appears second, after Languages
- [ ] "More…" button appears on groups with >10 tags (AI, Libraries, DevOps & Infra, Tools)
- [ ] Clicking "More…" expands all tags in that group
- [ ] 2 columns at 900px, 1 column at 600px