### PR TITLE
Broaden Sponda tagline to worldwide companies

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,7 +62,7 @@ const projects = [
     url: "https://sponda.capital",
     domain: "sponda.capital",
     description:
-      "Financial indicators for Brazilian public companies, built for value investors.",
+      "Financial indicators for public companies worldwide, built for value investors.",
     image: "/images/sponda.png",
     tech: [
       "Claude Code", "Codex",


### PR DESCRIPTION
## Summary
- Sponda now covers global tickers (US + BR), so the portfolio description saying "Brazilian public companies" is out of date — especially with the new screenshot showing US names.

## Test plan
- [ ] Sponda card copy reads "Financial indicators for public companies worldwide, built for value investors."